### PR TITLE
Add support for random deprecated RPC

### DIFF
--- a/autobuild/templates/wallet.conf.j2
+++ b/autobuild/templates/wallet.conf.j2
@@ -16,5 +16,8 @@ changetype=legacy
 {% if deprecatedrpc is defined and deprecatedrpc is sameas true %} 
 # Enable deprecated calls
 deprecatedrpc=signrawtransaction
+{% elif deprecatedrpc is defined and deprecatedrpc is string %} 
+# Enable deprecated calls
+deprecatedrpc={{ deprecatedrpc }}
 {% endif %}
 


### PR DESCRIPTION
Adds support for "random" deprecated RPCs. For example, SYS has 
```
deprecatedrpcs=addresses
```
Other coins may also have modified RPC behaviour in later versions and need persuading to continue returning data in a format expected by XBridge. 