### PR TITLE
fix(config): remove trailing commas in dgb and rvn base templates

### DIFF
--- a/autobuild/configs/dgb.base.j2
+++ b/autobuild/configs/dgb.base.j2
@@ -42,7 +42,7 @@
                 "xbridge_conf": "digibyte--v7.17.2.conf",
                 "wallet_conf": "digibyte--v7.17.2.conf",
                 "GetNewKeySupported": false
-            },            
+            }
         }
     }
 }

--- a/autobuild/configs/rvn.base.j2
+++ b/autobuild/configs/rvn.base.j2
@@ -77,7 +77,7 @@
                 "xbridge_conf": "raven--v4.1.0.conf",
                 "wallet_conf": "raven--v4.1.0.conf",
                 "GetNewKeySupported": false
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Trailing commas before closing braces in 'versions' objects caused json.loads() to fail with a JSONDecodeError